### PR TITLE
Add UTF8 as a default when exporting to prevent errors on Windows platforms

### DIFF
--- a/pyanx/pyanx.py
+++ b/pyanx/pyanx.py
@@ -134,7 +134,7 @@ class Pyanx(object):
 
     chart.add_ChartItemCollection(chart_item_collection)
 
-  def create(self, path, pretty=True):
+  def create(self, path, pretty=True, encoding='utf8'):
     chart = anx.Chart(IdReferenceLinking=False)
     chart.add_StrengthCollection(anx.StrengthCollection([
         anx.Strength(DotStyle="DotStyleDashed", Name="Dashed", Id="Dashed"),
@@ -146,5 +146,5 @@ class Pyanx(object):
     self.__add_entities(chart)
     self.__add_links(chart)
 
-    with open(path, 'w') as output_file:
+    with open(path, 'w', encoding=encoding) as output_file:
       chart.export(output_file, 0, pretty_print=pretty, namespacedef_=None)


### PR DESCRIPTION
This may be a bit opinionated, but when writing a "normal" string with some special unicode characters in the `description` parameter of `add_edge` or `add_node`, Windows platforms tend to complain with errors like this:
```
File "encodings\cp1252.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f60e' in position 2323: character maps to <undefined>
```
By setting `utf8` as a sane default, this no longer happens.

Note that users can still choose a different encoding if they really wish, by providing it as an argument to the `chart.create` method.